### PR TITLE
adds REPLhensibleSAM entry and fixes a typo

### DIFF
--- a/directory.txt
+++ b/directory.txt
@@ -52,7 +52,7 @@ Any other info: Olympic Weightlifte, not Olympic level but hopefully national le
 
 Community Handle: Are
 Name: Ryan
-Current Occupation: Prgorammer & Designer
+Current Occupation: Programmer & Designer
 Desired Occupation: Better programmer and designer
 Technologies I know: HTML, CSS, JavaScript, React, Node, Linux, LAMP/LEMP, Redux, Sass, Python, Liquid, ...more
 Technologies I'm learning/want to know: Python more and higher levels of everything
@@ -60,3 +60,13 @@ GitHub: Ar3Tea
 Short Bio: I've been off and on freelancing for a decade. I always want to be in tech, but life kept pulling me away from being directly in tech.
 From SEO to Product Management, I've always come back to programming and design
 Any other info: Full-time smart ass, resident cut up, musician, magician (not at the same time), lock picker,...more
+
+Community handle: REPLhensibleSAM
+Name: Sam
+Current Occupation: Student
+Desired Occupation: Software Engineer - Backend
+Technologies I know: **_(familiar):_** C, Python, Java, HTML/CSS, Git **_(basic):_** Clojure, JavaScript/TypeScript, C#, SQLite
+Technologies I'm learning/want to learn: Rust, ClojureScript, Elixir, F#, Prolog, and trying to continue to get better at all of the above + appropriate frameworks
+GitHub: https://github.com/samuelludwig
+Short Bio: I'm currently a fulltime Junior-year College CS Student after finally leaving my retail job of 3 years; I've technically been programming since Middle School, and have been _seriously_ programming for a bit over a year now.  
+Any other info: An avid Iain M. Banks fan, I always try to maintain the SAMWAF mentality (Sense Amid Madness, Wit Amidst Folly). I also maintain that Alastair Reid's [_Curiosity_](https://www.poetryarchive.org/poem/curiosity) is personally one of the most important peices of writing that has ever existed. 


### PR DESCRIPTION
Adds my entry (`REPLhensibleSAM`) and fixes a typo (`prgorammer` -> `programmer`) in the entry for Are.